### PR TITLE
Moved the temp directory for uploads to /var/tmp from /tmp

### DIFF
--- a/ostree-upload-server.py
+++ b/ostree-upload-server.py
@@ -85,7 +85,9 @@ class UploadWebApp(Flask):
         self.route("/upload", methods=["GET", "POST"])(self.upload)
         self.route("/push", methods=["GET", "PUT"])(self.push)
 
-        self._tempdir = tempfile.mkdtemp(prefix="ostree-upload-server-")
+        # These files might be huge and /tmp might be mounted on tmpfs
+        # so to avoid RAM exhaustion, we use /var/tmp
+        self._tempdir = tempfile.mkdtemp(dir="/var/tmp", prefix="ostree-upload-server-")
         atexit.register(shutil.rmtree, self._tempdir)
 
     def _check_auth(self):


### PR DESCRIPTION
This should prevent RAM exhaustion for filesystem where /tmp is mounted
in RAM though at a slight decrease in portability.

https://phabricator.endlessm.com/T19208