### PR TITLE
Set correct commit bindings on import

### DIFF
--- a/ostree_upload_server/flatpak_importer.py
+++ b/ostree_upload_server/flatpak_importer.py
@@ -207,8 +207,8 @@ class FlatpakImporter():
 
             # Sign the commit
             if sign_key:
-                logging.info("Signing with key {} from {}".format(sign_key,
-                                                                  keyring_dir))
+                logging.info("Signing with key {} from {}"
+                             .format(sign_key, keyring_dir.get_path()))
                 try:
                     repo.sign_commit(commit_checksum=commit,
                                      key_id=sign_key,

--- a/ostree_upload_server/flatpak_importer.py
+++ b/ostree_upload_server/flatpak_importer.py
@@ -24,6 +24,8 @@ OSTREE_STATIC_DELTA_SUPERBLOCK_FORMAT = \
     ")"
 
 # Indices into the commit gvariant tuple
+COMMIT_SUBJECT_INDEX = 3
+COMMIT_BODY_INDEX = 4
 COMMIT_TREE_CONTENT_CHECKSUM_INDEX = 6
 COMMIT_TREE_METADATA_CHECKSUM_INDEX = 7
 
@@ -104,6 +106,95 @@ class FlatpakImporter():
                 raise
 
         return collection_id
+
+    @staticmethod
+    def _copy_commit(repo, src_rev, dest_ref):
+        """Copy commit src_rev to dest_ref
+
+        This makes the new commit at dest_ref have the proper collection
+        binding for this repo. The caller is expected to manage the
+        ostree transaction.
+
+        This is like "flatpak build-commit-from", but we need more
+        control over the transaction.
+        """
+        logging.info('Copying commit %s to %s', src_rev, dest_ref)
+
+        _, src_root, _ = repo.read_commit(src_rev)
+        _, src_variant, src_state = repo.load_commit(src_rev)
+
+        # Only copy normal commits
+        if src_state != 0:
+            raise Exception('Cannot copy irregular commit {}'
+                            .format(src_rev))
+
+        # If the dest ref exists, use the current commit as the new
+        # commit's parent
+        _, dest_parent = repo.resolve_rev_ext(
+            dest_ref, allow_noent=True,
+            flags=OSTree.RepoResolveRevExtFlags.REPO_RESOLVE_REV_EXT_NONE)
+        if dest_parent is not None:
+            logging.info('Using %s as new commit parent', dest_parent)
+
+        # Make a copy of the commit metadata to update. Like flatpak
+        # build-commit-from, the detached metadata is not copied since
+        # the only known usage is for GPG signatures, which would become
+        # invalid.
+        commit_metadata = GLib.VariantDict.new(src_variant.get_child_value(0))
+
+        # Set the collection binding if the repo has a collection ID,
+        # otherwise remove it
+        collection_id = FlatpakImporter._get_collection_id(repo)
+        if collection_id is not None:
+            commit_metadata.insert_value(
+                OSTree.COMMIT_META_KEY_COLLECTION_BINDING,
+                GLib.Variant('s', collection_id))
+        else:
+            commit_metadata.remove(
+                OSTree.COMMIT_META_KEY_COLLECTION_BINDING)
+
+        # Include the destination ref in the ref bindings
+        ref_bindings = commit_metadata.lookup_value(
+            OSTree.COMMIT_META_KEY_REF_BINDING,
+            GLib.VariantType('as'))
+        if ref_bindings is None:
+            ref_bindings = []
+        ref_bindings = set(ref_bindings)
+        ref_bindings.add(dest_ref)
+        commit_metadata.insert_value(
+            OSTree.COMMIT_META_KEY_REF_BINDING,
+            GLib.Variant('as', sorted(ref_bindings)))
+
+        # Add flatpak specific metadata. xa.ref is deprecated, but some
+        # flatpak clients might expect it. xa.from_commit will be used
+        # by the app verifier to make sure the commit it sent actually
+        # got there
+        commit_metadata.insert_value('xa.ref',
+                                     GLib.Variant('s', dest_ref))
+        commit_metadata.insert_value('xa.from_commit',
+                                     GLib.Variant('s', src_rev))
+
+        # Convert from GVariantDict to GVariant vardict
+        commit_metadata = commit_metadata.end()
+
+        # Copy other commit data from source commit
+        commit_subject = src_variant[COMMIT_SUBJECT_INDEX]
+        commit_body = src_variant[COMMIT_BODY_INDEX]
+        commit_time = OSTree.commit_get_timestamp(src_variant)
+
+        # Make the new commit assuming the caller started a transaction
+        mtree = OSTree.MutableTree.new()
+        repo.write_directory_to_mtree(src_root, mtree, None)
+        _, dest_root = repo.write_mtree(mtree)
+        _, dest_checksum = repo.write_commit_with_time(dest_parent,
+                                                       commit_subject,
+                                                       commit_body,
+                                                       commit_metadata,
+                                                       dest_root,
+                                                       commit_time)
+        logging.info('Created new commit %s', dest_checksum)
+
+        return dest_checksum
 
     @staticmethod
     def import_flatpak(flatpak,
@@ -206,7 +297,6 @@ class FlatpakImporter():
         try:
             # Prepare transaction
             repo.prepare_transaction(None)
-            repo.transaction_set_ref(None, metadata['ref'], commit)
 
             # Execute the delta
             flatpak_file = Gio.File.new_for_path(flatpak)
@@ -238,12 +328,16 @@ class FlatpakImporter():
             else:
                 raise Exception("Committed metadata does not match the static delta header")
 
+            # Copy the commit to get correct collection and ref bindings
+            new_commit = FlatpakImporter._copy_commit(repo, commit,
+                                                      metadata['ref'])
+
             # Sign the commit
             if sign_key:
                 logging.info("Signing with key {} from {}"
                              .format(sign_key, keyring_dir.get_path()))
                 try:
-                    repo.sign_commit(commit_checksum=commit,
+                    repo.sign_commit(commit_checksum=new_commit,
                                      key_id=sign_key,
                                      homedir=gpg_homedir,
                                      cancellable=None)
@@ -253,6 +347,12 @@ class FlatpakImporter():
                         logging.debug("already signed with key " + sign_key)
                     else:
                         raise
+
+            # Set the ref to the new commit. Ideally this would use
+            # transaction_set_collection_ref, but that's not available
+            # on SOMA and the commit was set to use this repo's
+            # collection ID, so it wouldn't make any difference.
+            repo.transaction_set_ref(None, metadata['ref'], new_commit)
 
             # Commit the transaction
             repo.commit_transaction(None)

--- a/ostree_upload_server/task/receive.py
+++ b/ostree_upload_server/task/receive.py
@@ -33,7 +33,7 @@ class ReceiveTask(BaseTask):
                 self.set_state(TaskState.COMPLETED)
 
                 logging.info("Completed task {}".format(self.get_name()))
-            except GLib.Error as e:
+            except Exception as e:
                 self.set_state(TaskState.FAILED)
 
                 logging.error("Failed task {}".format(e))


### PR DESCRIPTION
Now that we're enforcing the collection and ref bindings, they need to be set accurately for new commits. Create new commits based on the bundled commits with the correct bindings for the destination repository.

https://phabricator.endlessm.com/T19126