### PR TITLE
Switch to python-magic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Endless Services Team <services@endlessm.com>
 
 RUN apt-get update && \

--- a/ostree_upload_server/bundle_importer.py
+++ b/ostree_upload_server/bundle_importer.py
@@ -2,11 +2,7 @@ import inspect
 import logging
 import os
 
-# This is NOT the pypi python-magic module but the file-magic
-# module from there. It corresponds to the python-magic OS package
-# for Ubuntu for which the former has no candidate. The packages are
-# not API compatible!
-import magic as file_magic
+import magic
 
 from ConfigParser import ConfigParser
 
@@ -51,10 +47,7 @@ class BundleImporter(object):
             logging.info("Set %s = '%s'", arg, locals()[arg])
 
         # Find the appropriate importer based on mimetype
-        magic = file_magic.open(file_magic.MIME_TYPE)
-        magic.load()
-
-        mime_type = magic.file(bundle)
+        mime_type = magic.from_file(bundle, mime=True)
 
         importer_class = filter(lambda ext: mime_type == ext.MIME_TYPE,
                                 BundleImporter.BUNDLE_IMPORTERS)[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ appdirs==1.4.3
 certifi==2018.1.18
 chardet==3.0.4
 click==6.7
-file-magic==0.3.0
 Flask==0.12.2
 Flask-API==1.0
 gevent==1.2.2
@@ -14,6 +13,7 @@ Jinja2==2.10
 MarkupSafe==1.0
 packaging==17.1
 pyparsing==2.2.0
+python-magic==0.4.18
 requests==2.18.4
 six==1.11.0
 urllib3==1.22


### PR DESCRIPTION
This is now available in Ubuntu 18.04+ and has actually replaced the
older file-magic bindings.

https://phabricator.endlessm.com/T30115